### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy Gamemodstudios Website to GitHub Pages
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Gamemodstudios/Gamemodstudios.github.io/security/code-scanning/8](https://github.com/Gamemodstudios/Gamemodstudios.github.io/security/code-scanning/8)

To fix the problem, add a `permissions` key to the workflow or the specific job. Since the workflow deploys to GitHub Pages using `peaceiris/actions-gh-pages@v4`, it needs to push to the `gh-pages` branch, which requires `contents: write`. The minimal and most secure fix is to add `permissions: contents: write` at the workflow level (just after the `name:` and before `on:`), or at the job level (under `build-and-deploy:`). Adding it at the workflow level is preferred for clarity and to cover all jobs (if more are added in the future). No imports or other code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
